### PR TITLE
Frankkim/update tap to store nested data as jsonb field

### DIFF
--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -98,8 +98,6 @@ def _literal_only_schema(schema):
 
 
 def _create_subtable(table_path, table_json_schema, key_prop_schemas, subtables, level):
-    print(f"Creating subtable for {table_path} with schema {table_json_schema}")
-
     traceback.print_stack()
 
     if json_schema.is_object(table_json_schema['items']):

--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -1,7 +1,5 @@
 from copy import deepcopy
 from target_postgres import json_schema, singer
-import traceback
-import json
 
 def to_table_batches(schema, key_properties, records):
     """
@@ -98,7 +96,6 @@ def _literal_only_schema(schema):
 
 
 def _create_subtable(table_path, table_json_schema, key_prop_schemas, subtables, level):
-    traceback.print_stack()
 
     if json_schema.is_object(table_json_schema['items']):
         new_properties = table_json_schema['items']['properties']

--- a/target_postgres/denest.py
+++ b/target_postgres/denest.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
-
 from target_postgres import json_schema, singer
-
+import traceback
+import json
 
 def to_table_batches(schema, key_properties, records):
     """
@@ -98,6 +98,10 @@ def _literal_only_schema(schema):
 
 
 def _create_subtable(table_path, table_json_schema, key_prop_schemas, subtables, level):
+    print(f"Creating subtable for {table_path} with schema {table_json_schema}")
+
+    traceback.print_stack()
+
     if json_schema.is_object(table_json_schema['items']):
         new_properties = table_json_schema['items']['properties']
     else:
@@ -156,7 +160,7 @@ def _denest_schema_helper(
     key_prop_schemas,
     subtables,
     level):
-
+    
     for prop, item_json_schema in _denest_schema__singular_schemas(table_json_schema):
 
         if json_schema.is_object(item_json_schema):
@@ -196,30 +200,10 @@ def _denest_schema(
 
     new_properties = {}
     for prop, item_json_schema in _denest_schema__singular_schemas(table_json_schema):
-
-        if json_schema.is_object(item_json_schema):
-            _denest_schema_helper(table_path + (prop,),
-                                (prop,),
-                                item_json_schema,
-                                json_schema.is_nullable(item_json_schema),
-                                new_properties,
-                                key_prop_schemas,
-                                subtables,
-                                level)
-
-        elif json_schema.is_iterable(item_json_schema):
-            _create_subtable(table_path + (prop,),
-                            item_json_schema,
-                            key_prop_schemas,
-                            subtables,
-                            level + 1)
-
-        elif json_schema.is_literal(item_json_schema):
-            if (prop,) in new_properties:
-                new_properties[(prop,)]['anyOf'].append(item_json_schema)
-            else:
-                new_properties[(prop,)] = {'anyOf': [item_json_schema]}
-
+        if (prop,) in new_properties:
+            new_properties[(prop,)]['anyOf'].append(item_json_schema)
+        else:
+            new_properties[(prop,)] = {'anyOf': [item_json_schema]}
 
     table_json_schema['properties'] = new_properties
 
@@ -245,60 +229,6 @@ def _get_streamed_table_records(key_properties, records):
     return records_map
 
 
-def _denest_subrecord(table_path,
-                      prop_path,
-                      parent_record,
-                      record,
-                      records_map,
-                      key_properties,
-                      pk_fks,
-                      level):
-    """"""
-    """
-    {...}
-    """
-    for prop, value in record.items():
-        """
-        str : {...} | [...] | ???None??? | <literal>
-        """
-
-        if isinstance(value, dict):
-            """
-            {...}
-            """
-            _denest_subrecord(table_path + (prop,),
-                              prop_path + (prop,),
-                              parent_record,
-                              value,
-                              records_map,
-                              key_properties,
-                              pk_fks,
-                              level)
-
-        elif isinstance(value, list):
-            """
-            [...]
-            """
-            _denest_records(table_path + (prop,),
-                            value,
-                            records_map,
-                            key_properties,
-                            pk_fks=pk_fks,
-                            level=level + 1)
-
-        elif value is None:
-            """
-            None
-            """
-            continue
-
-        else:
-            """
-            <literal>
-            """
-            parent_record[prop_path + (prop,)] = (json_schema.python_type(value), value)
-
-
 def _denest_record(table_path, record, records_map, key_properties, pk_fks, level):
     """"""
     """
@@ -309,32 +239,7 @@ def _denest_record(table_path, record, records_map, key_properties, pk_fks, leve
         """
         str : {...} | [...] | None | <literal>
         """
-
-        if isinstance(value, dict):
-            """
-            {...}
-            """
-            _denest_subrecord(table_path + (prop,),
-                              (prop,),
-                              denested_record,
-                              value,
-                              records_map,
-                              key_properties,
-                              pk_fks,
-                              level)
-
-        elif isinstance(value, list):
-            """
-            [...]
-            """
-            _denest_records(table_path + (prop,),
-                            value,
-                            records_map,
-                            key_properties,
-                            pk_fks=pk_fks,
-                            level=level + 1)
-
-        elif value is None:
+        if value is None:
             """
             None
             """
@@ -348,6 +253,7 @@ def _denest_record(table_path, record, records_map, key_properties, pk_fks, leve
 
     if table_path not in records_map:
         records_map[table_path] = []
+
     records_map[table_path].append(denested_record)
 
 

--- a/target_postgres/json_schema.py
+++ b/target_postgres/json_schema.py
@@ -22,9 +22,10 @@ _PYTHON_TYPE_TO_JSON_SCHEMA = {
     bool: BOOLEAN,
     str: STRING,
     type(None): NULL,
-    decimal.Decimal: NUMBER
+    decimal.Decimal: NUMBER,
+    dict: OBJECT,
+    list: ARRAY
 }
-
 
 def python_type(x):
     """
@@ -559,7 +560,9 @@ _shorthand_mapping = {
     'number': 'f',
     'integer': 'i',
     'boolean': 'b',
-    'date-time': 't'
+    'date-time': 't',
+    'object': 'o',
+    'array': 'a'
 }
 
 

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -428,8 +428,6 @@ class PostgresTarget(SQLInterface):
             sql.Identifier(self.postgres_schema),
             sql.Identifier(name))
 
-        print(create_table_sql)
-
         cur.execute(sql.SQL('{} ();').format(create_table_sql))
 
         self._set_table_metadata(cur, name, {'path': path,
@@ -567,19 +565,11 @@ class PostgresTarget(SQLInterface):
                          columns,
                          csv_rows):
 
-        print("-------------------------")
-        print(csv_rows)
-        print("-------------------------")
-
         copy = sql.SQL('COPY {}.{} ({}) FROM STDIN WITH CSV NULL AS {}').format(
             sql.Identifier(self.postgres_schema),
             sql.Identifier(temp_table_name),
             sql.SQL(', ').join(map(sql.Identifier, columns)),
             sql.Literal(RESERVED_NULL_DEFAULT))
-        
-        print("-------------------------")
-        print(type(cur))
-        print("-------------------------")
         
         cur.copy_expert(copy, csv_rows)
 
@@ -594,11 +584,7 @@ class PostgresTarget(SQLInterface):
                                           canonicalized_key_properties,
                                           columns,
                                           subkeys)
-        
-        print("-------------------------")
-        print(update_sql)
-        print("-------------------------")
-        
+
         cur.execute(update_sql)
 
     def write_table_batch(self, cur, table_batch, metadata):
@@ -630,7 +616,6 @@ class PostgresTarget(SQLInterface):
                 for header in csv_headers:
                     if header in row and isinstance(row[header], (dict, list)):
                         row[header] = json.dumps(row[header], default=handle_decimal)
-                        print(json.dumps(row[header]))
 
                 with io.StringIO() as out:
                     writer = csv.DictWriter(out, csv_headers)
@@ -640,8 +625,6 @@ class PostgresTarget(SQLInterface):
                 return ''
 
         csv_rows = TransformStream(transform)
-
-        print(table_batch['records'])
 
         ## Persist csv rows
         self.persist_csv_rows(cur,
@@ -846,7 +829,6 @@ class PostgresTarget(SQLInterface):
         :return: JSONSchema
         """
         _format = None
-        print(f"sql type {sql_type}")
         
         if sql_type == 'timestamp with time zone':
             json_type = 'string'

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -134,6 +134,10 @@ class BufferedSingerStream():
         self.__lifetime_max_version = version
 
     def add_record_message(self, record_message):
+        print("----------------")
+        print(record_message)
+        print("----------------")
+
         add_record = True
 
         self.__update_version(record_message.get('version'))

--- a/target_postgres/singer_stream.py
+++ b/target_postgres/singer_stream.py
@@ -134,10 +134,6 @@ class BufferedSingerStream():
         self.__lifetime_max_version = version
 
     def add_record_message(self, record_message):
-        print("----------------")
-        print(record_message)
-        print("----------------")
-
         add_record = True
 
         self.__update_version(record_message.get('version'))


### PR DESCRIPTION
# PR Description for `target-postgres`

## Title
Disable Table De-Nesting and Store All Nested JSON Objects in JSONB Columns

## Description

### Summary
This Pull Request addresses the handling of nested JSON objects in `target-postgres`. Instead of de-nesting the tables, all nested structures—including arrays—will now be stored directly in JSONB columns.

### Motivation
Handling nested objects by creating separate tables (de-nesting) can result in a complex schema that's hard to manage and query. By storing the nested objects directly as JSONB, we simplify the schema and make it easier to query nested data.

### Changes
- Disabled the table de-nesting logic.
- All nested JSON objects and arrays are now saved in JSONB columns.
- Updated the test cases to reflect these changes.

### How it works
Here is an example to illustrate the new behavior:

#### Previous Behavior
For a JSON payload like the following:
```json
{
  "name": "John",
  "info": {
    "email": "john@example.com",
    "address": {
      "city": "NY",
      "state": "NY"
    }
  }
}
```
The data would be saved in multiple tables, such as main_table, info_table, and address_table.

New Behavior
Now, the data will be saved in a single table with JSONB columns:

| name  | info                                        |
|-------|---------------------------------------------|
| John  | {"email": "john@example.com", "address": {"city": "NY", "state": "NY"}} |

